### PR TITLE
Relax version check for boto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyqldb~=1.0.0rc2
 argparse~=1.4.0
 amazon.ion~=0.5.0
-boto3~=1.9.237
+boto3~=1.9
 


### PR DESCRIPTION
The version requirement for boto during installation is too specific.
Changing requirement to allow for a more flexible requirement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
