### PR TITLE
Fail fast on no credentials and lock driver version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 1.0.1
 
-## :tada: Enhancements
+## :bug: Fixes
 
 * Error out of shell immediately when no credentials are present as reported in [issue#14](https://github.com/awslabs/amazon-qldb-shell/issues/14)
-
+* Lock driver and amazon ion versions during shell installation
 
 # 1.0.0 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.1
+
+## :tada: Enhancements
+
+* Error out of shell immediately when no credentials are present as reported in [issue#14](https://github.com/awslabs/amazon-qldb-shell/issues/14)
+
+
 # 1.0.0 
 
 ## :tada: Enhancements

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ qldbshell> SELECT * FROM TestTable
 qldbshell> exit
 ```
 We use backticks in the example above since we use are using Ion literals. For more on querying Ion literals, go [here](https://docs.aws.amazon.com/qldb/latest/developerguide/ql-reference.query.html).
-Each statement between connect and disconnect is considered as a transaction.
+Each statement except exit is considered as a transaction.
 
 ### See also
 

--- a/qldbshell/__init__.py
+++ b/qldbshell/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-version = '1.0.0'
+version = '1.0.1'

--- a/qldbshell/errors/__init__.py
+++ b/qldbshell/errors/__init__.py
@@ -13,3 +13,6 @@
 
 class IllegalStateError(Exception):
     pass
+
+class NoCredentialError(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@
 from setuptools import setup, find_packages
 from qldbshell import version
 
-requires = ['pyqldb>=1.0.0rc2',
+requires = ['pyqldb>=1.0.0rc2,<3.0.0rc1',
             'boto3>=1.9.237',
-            'amazon.ion>=0.5.0']
+            'amazon.ion>=0.5.0,<0.6.0']
 
 setup(
     name='qldbshell',

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -10,10 +10,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from botocore.exceptions import EndpointConnectionError, ClientError
+from botocore.exceptions import EndpointConnectionError, ClientError, NoCredentialsError
 from pyqldb.driver.pooled_qldb_driver import PooledQldbDriver
 from pyqldb.errors import SessionPoolEmptyError
 
+from qldbshell.errors import NoCredentialError
 from qldbshell.qldb_shell import QldbShell
 from unittest import TestCase
 from unittest.mock import patch
@@ -29,6 +30,13 @@ class TestQldbShell(TestCase):
         mock_shell = QldbShell(None, mockdriver)
 
         assert mock_shell is not None
+
+    @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')
+    def test_constructor_no_credentials_throws_exception(self, mockdriver):
+        mockdriver.get_session.side_effect = NoCredentialsError()
+
+        with self.assertRaises(NoCredentialError):
+            QldbShell(None, mockdriver)
 
     @patch('pyqldb.session.pooled_qldb_session.PooledQldbSession')
     @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-qldb-shell/issues/14 , https://github.com/awslabs/amazon-qldb-shell/issues/15

*Description of changes:*
The Pull request contains 2 changes:
1. Fail fast on no credentials and non-existant ledger : If there are no credentials configured, the shell will fail immediately. The shell will also fail if a ledger does not exist.
2. Lock Driver versions installed during setup : A new release of the QLDB Python Driver breaks the shell for new users. The change limits the version of driver installed as part of the shell setup. The recommendation is to downgrade the python driver to v2 or v1 for users working on the shell.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
