### PR TITLE
Modify dependency on driver to github branch. Add shell user agent.

### DIFF
--- a/qldbshell/__main__.py
+++ b/qldbshell/__main__.py
@@ -15,13 +15,13 @@
 
 import argparse
 import logging
-import sys
 import boto3
 
-from botocore.exceptions import ClientError, EndpointConnectionError
+from botocore.config import Config
 from pyqldb.driver.pooled_qldb_driver import PooledQldbDriver
 
 from qldbshell.errors import IllegalStateError
+from . import version
 from .qldb_shell import QldbShell
 
 
@@ -75,8 +75,10 @@ def main():
 
     if args.ledger is None:
         raise IllegalStateError("Ledger must be specified")
+    SERVICE_DESCRIPTION = 'QLDB Shell for Python v{}'.format(version)
+    SHELL_CONFIG = Config(user_agent_extra=SERVICE_DESCRIPTION)
     pooled_driver = PooledQldbDriver(
-        args.ledger, endpoint_url=args.qldb_session_endpoint, boto3_session=botoSession)
+        args.ledger, endpoint_url=args.qldb_session_endpoint, boto3_session=botoSession, config=SHELL_CONFIG)
     cli = QldbShell(args.profile, pooled_driver=pooled_driver)
     cli.cmdloop()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pyqldb~=1.0.0rc2
+#Commit on v2.x-shell branch of pyqldb
+-e git+git://github.com/awslabs/amazon-qldb-driver-python.git@dcea856c4c2023f8505db22c977755ccd48d7183#egg=pyqldb
 argparse~=1.4.0
 amazon.ion~=0.5.0
 boto3~=1.9

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@
 from setuptools import setup, find_packages
 from qldbshell import version
 
-requires = ['pyqldb>=1.0.0rc2,<3.0.0rc1',
-            'boto3>=1.9.237',
-            'amazon.ion>=0.5.0,<0.6.0']
+requires = ['boto3>=1.9.237',
+            'amazon.ion>=0.5.0,<0.6.0',
+            #commit on v2.x-shell branch of pyqldb
+            'pyqldb @ git+git://github.com/awslabs/amazon-qldb-driver-python.git@dcea856c4c2023f8505db22c977755ccd48d7183']
 
 setup(
     name='qldbshell',
@@ -27,6 +28,8 @@ setup(
     long_description_content_type='text/markdown',
     author='Amazon Web Services',
     install_requires=requires,
+    #dependency on commit in v2.x-shell branch of pyqldb
+    dependency_links=["git+git://github.com/awslabs/amazon-qldb-driver-python.git@dcea856c4c2023f8505db22c977755ccd48d7183#egg=pyqldb"],
     license="Apache License 2.0",
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Added user agent extra for QLDB Shell.
Cleaned some unused imports.
Changed depedency on python driver from pip to a separate branch.
Used https://www.python.org/dev/peps/pep-0508/ to use the github repo link as a requirement
and to work with pipv20 onwards. Depedency link is still important for older versions of pip.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
