### PR TITLE
Add capability to interact with transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
-# 1.0.1
+# 1.1.0 (2020-10-22)
+
+## :bug: Fixes
+
+* Fixed empty line repeating the last command used in the shell. Now, an empty line does not repeat the last command.
+
+## :tada: Enhancements
+
+* Added `quit` and `Ctrl + D` as ways to exit the shell along with existing `exit` command.
+* Added interactive and non-interactive transactions to the shell. More details can be found in the [release notes](http://github.com/awslabs/amazon-qldb-shell/releases/tag/v1.1.0).
+
+# 1.0.1 (2020-07-01)
 
 ## :bug: Fixes
 
 * Error out of shell immediately when no credentials are present as reported in [issue#14](https://github.com/awslabs/amazon-qldb-shell/issues/14)
 * Lock driver and amazon ion versions during shell installation
 
-# 1.0.0 
+# 1.0.0 (2020-04-20)
 
 ## :tada: Enhancements
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developergui
 
 ### Python 3.4 or later
 
-The driver requires Python 3.4 or later. Please see the link below for more detail to install Python:
+The shell requires Python 3.4 or later. Please see the link below for more detail to install Python:
 
 * [Python Installation](https://www.python.org/downloads/)
 

--- a/qldbshell/__init__.py
+++ b/qldbshell/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-version = '1.0.1'
+version = '1.1.0'

--- a/qldbshell/errors/__init__.py
+++ b/qldbshell/errors/__init__.py
@@ -10,9 +10,31 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+import re
 
 class IllegalStateError(Exception):
     pass
 
 class NoCredentialError(Exception):
     pass
+
+class QuerySyntaxError(Exception):
+    pass
+
+def is_transaction_expired_exception(e):
+    """
+    Checks if exception occurred for an expired transaction
+
+    :type e: :py:class:`botocore.exceptions.ClientError`
+    :param e: The ClientError caught.
+
+    :rtype: bool
+    :return: True if the exception denote that a transaction has expired. False otherwise.
+    """
+    is_invalid_session = e.response['Error']['Code'] == 'InvalidSessionException'
+
+    if "Message" in e.response["Error"]:
+        return is_invalid_session and re.search("Transaction .* has expired", e.response["Error"]["Message"])
+
+    return False
+

--- a/qldbshell/outcome.py
+++ b/qldbshell/outcome.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Outcome(Enum):
+    COMMIT = 1
+    ABORT = 2

--- a/qldbshell/qldb_shell.py
+++ b/qldbshell/qldb_shell.py
@@ -14,21 +14,19 @@ import cmd
 import logging
 from textwrap import dedent
 
-from amazon.ion.simpleion import dumps
+
 from botocore.exceptions import ClientError, EndpointConnectionError, NoCredentialsError
-from pyqldb.cursor.buffered_cursor import BufferedCursor
 from pyqldb.errors import SessionPoolEmptyError
 
 from qldbshell.decorators import (time_this, zero_noun_command)
 
 from . import version
-from .errors import NoCredentialError
+from .outcome import Outcome
+from .errors import NoCredentialError, QuerySyntaxError
+from .errors import is_transaction_expired_exception
+from .shell_transaction import ShellTransaction
 
-
-def print_result(cursor: BufferedCursor):
-    results = list(map(lambda x: dumps(x, binary=False,
-                                                  indent=' ', omit_version_marker=True), cursor))
-    logging.info("\n" + str(',\n').join(results))
+from qldbshell.shell_utils import print_result
 
 
 class QldbShell(cmd.Cmd):
@@ -45,15 +43,19 @@ class QldbShell(cmd.Cmd):
             session.close()
         except NoCredentialsError:
             raise NoCredentialError("No credentials present") from None
-        self._in_session = True
+        self._is_interactive_transaction = False
+        self._driver_transaction = None
+        self._transaction_session = None
 
 
     prompt = 'qldbshell > '
 
     intro = dedent(f"""\
         Welcome to the Amazon QLDB Shell version {version}
-
-        All future commands will be interpreted as PartiQL statements until the 'exit' command is issued.
+        Use 'start' to initiate and interact with a transaction. 'commit' and 'abort' to commit or abort a transaction.
+        Use 'start; statement 1; statement 2; commit; start; statement 3; commit' to create transactions non-interactively.
+        All other commands will be interpreted as PartiQL statements until the 'exit' command is issued.
+        
     """)
 
     def onecmd(self, line):
@@ -83,8 +85,13 @@ class QldbShell(cmd.Cmd):
 
     @time_this
     def default(self, line):
-        # If currently in a session, treat unrecognized input as PartiQL. Else, do nothing.
-        if self._in_session:
+        if line.strip().lower().startswith("start") or self._is_interactive_transaction:
+            self.handle_transaction_flow(line)
+        elif (self._is_interactive_transaction is False) and (line.lower().strip().strip(";") == "abort"):
+            logging.info("'abort' can only be used on an active transaction")
+        elif (self._is_interactive_transaction is False) and (line.lower().strip().strip(";") == "commit"):
+            logging.info("'commit' can only be used on an active transaction")
+        else:
             session = self._driver.get_session()
             try:
                 print_result(session.execute_lambda(
@@ -93,5 +100,109 @@ class QldbShell(cmd.Cmd):
                 logging.warning(f'Error while executing query: {e}')
             finally:
                 session.close()
-        else:
-            self.do_help('')
+
+    def handle_transaction_flow(self, line):
+        try:
+            shell_transactions = self.process_input(line)
+            self.run_transactions(shell_transactions)
+        except QuerySyntaxError as qse:
+            logging.warning(f'Error in query: {qse}')
+
+        except ClientError as ce:
+            if is_transaction_expired_exception(ce):
+                logging.info("Transaction expired.")
+            else:
+                logging.warning(f'Error in query: {ce}')
+            self.close_interactive_transaction()
+            self._transaction_session = None
+
+    def run_transactions(self, shell_transactions):
+        for shell_transaction in shell_transactions:
+            self.handle_transaction(shell_transaction)
+
+    def process_input(self, input_line):
+        openTx = self._is_interactive_transaction
+        statements = [statement.strip() for statement in input_line.strip().strip(";").split(';')]
+        shell_transactions = []
+        shell_transaction = None
+        for statement in statements:
+            if statement.lower() == "start":
+                if openTx:
+                    raise QuerySyntaxError("Transaction needs to be committed or aborted before starting new one")
+                openTx = True
+                shell_transaction = ShellTransaction([], None)
+            elif statement.lower() == "commit":
+                if openTx is False:
+                    raise QuerySyntaxError("Commit used before transaction was started")
+                if shell_transaction is None:
+                    shell_transaction = ShellTransaction([], None)
+                shell_transaction.set_outcome(Outcome.COMMIT)
+                openTx = False
+                shell_transactions.append(shell_transaction)
+                shell_transaction = None
+            elif statement.lower() == "abort":
+                if openTx is False:
+                    raise QuerySyntaxError("Abort used before transaction was started")
+                if shell_transaction is None:
+                    shell_transaction = ShellTransaction([], None)
+                shell_transaction.set_outcome(Outcome.ABORT)
+                openTx = False
+                shell_transactions.append(shell_transaction)
+                shell_transaction = None
+            elif statement.lower().strip() == "":
+                continue
+            else:
+                if openTx is False:
+                    raise QuerySyntaxError("A PartiQL statement was used before a transaction was started")
+                if shell_transaction is None:
+                    shell_transaction = ShellTransaction([], None)
+                shell_transaction.add_query(statement)
+        if shell_transaction is not None:
+            shell_transactions.append(shell_transaction)
+        return shell_transactions
+
+    def handle_transaction(self, shell_transaction):
+        if self._transaction_session is None:
+            self._transaction_session = self._driver.get_session()
+
+        if self._driver_transaction is None:
+            self._driver_transaction = self._transaction_session.start_transaction()
+        transaction_id = self._driver_transaction.transaction_id
+
+        if shell_transaction.is_start():
+            self.open_interactive_transaction(self._driver_transaction)
+            self._transaction_session = self._transaction_session
+            return
+        elif shell_transaction.is_open():
+            self.open_interactive_transaction(self._driver_transaction)
+            self._transaction_session = self._transaction_session
+
+        try:
+            shell_transaction.run_transaction(self._driver_transaction)
+        except ClientError as ce:
+            shell_transaction.set_outcome(Outcome.ABORT)
+            logging.info("Transaction with transaction_id {} aborted".format(transaction_id))
+            shell_transaction.execute_outcome(self._driver_transaction)
+            raise ce
+        shell_transaction.execute_outcome(self._driver_transaction)
+
+        if shell_transaction.get_outcome() is not None:
+            if shell_transaction.get_outcome() == Outcome.ABORT:
+                logging.info("Transaction with transaction_id {} aborted".format(transaction_id))
+            elif shell_transaction.get_outcome() == Outcome.COMMIT:
+                logging.info("Transaction with transaction_id {} committed".format(transaction_id))
+
+        if shell_transaction.get_outcome() is not None:
+            self.close_interactive_transaction()
+            self._transaction_session.close()
+            self._transaction_session = None
+
+    def close_interactive_transaction(self):
+        self._driver_transaction = None
+        self.prompt = 'qldbshell > '
+        self._is_interactive_transaction = False
+
+    def open_interactive_transaction(self, driver_transaction):
+        self._driver_transaction = driver_transaction
+        self.prompt = 'qldbshell(tx: {}) > '.format(self._driver_transaction.transaction_id)
+        self._is_interactive_transaction = True

--- a/qldbshell/shell_transaction.py
+++ b/qldbshell/shell_transaction.py
@@ -1,0 +1,47 @@
+from botocore.exceptions import ClientError
+
+from .outcome import Outcome
+from qldbshell.shell_utils import print_result
+
+
+class ShellTransaction:
+
+    def __init__(self, queries, outcome):
+        self._queries = queries
+        self._outcome = outcome
+        self._start = True
+
+    def get_outcome(self):
+        return self._outcome
+
+    def is_start(self):
+        return self._start and (len(self._queries) == 0)
+
+    def is_open(self):
+        return self._start and (len(self._queries) > 0)
+
+    def run_transaction(self, driver_transaction):
+        for query in self._queries:
+            try:
+                print_result(driver_transaction.execute_statement(query))
+            except ClientError as ce:
+                driver_transaction.abort()
+                raise ce
+
+    def execute_outcome(self, driver_transaction):
+        if self._outcome == Outcome.ABORT:
+            driver_transaction.abort()
+        elif self._outcome == Outcome.COMMIT:
+            driver_transaction.commit()
+        else:
+            return
+        return
+
+    def set_outcome(self, outcome):
+        self._outcome = outcome
+        self._start = False
+
+    def add_query(self, query):
+        self._queries.append(query)
+        self._start = True
+

--- a/qldbshell/shell_utils.py
+++ b/qldbshell/shell_utils.py
@@ -1,0 +1,9 @@
+from pyqldb.cursor.buffered_cursor import BufferedCursor
+import logging
+from amazon.ion.simpleion import dumps
+
+
+def print_result(cursor: BufferedCursor):
+    results = list(map(lambda x: dumps(x, binary=False,
+                                        indent=' ', omit_version_marker=True), cursor))
+    logging.info("\n" + str(',\n').join(results))


### PR DESCRIPTION

*Description of changes:*
Add intereactive transactions that timeout.
    Add non-interactive transactions that can be setup and run.
    start starts a transaction.
    commit/abort commits or aborts a transaction.
    start; statement1; statement2; commit creates a new transaction
   
Minor changes on quit, exit, emptyline and help
Allow quit to exit the shell.
    Allow any casing of exit and quit to exit the shell.
    Do nothing on empty line.
    Add instruction on help.
    Change README and Update CHANGELOG.
    Add minor documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
