### PR TITLE
Support escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-#1.2.0 (2020-11-13)
+# 1.2.1 (2020-11-24)
+
+## :bug: Fixes
+
+* Fixed bug where the shell was not processing escape sequences in user input.
+
+# 1.2.0 (2020-11-13)
 ## :tada: Enhancements
 * Added `clear` to clear the screen.
 * Remove pyqldb as dependency and add driver submodule.

--- a/qldbshell/__init__.py
+++ b/qldbshell/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-version = '1.2.0'
+version = '1.2.1'

--- a/qldbshell/qldb_shell.py
+++ b/qldbshell/qldb_shell.py
@@ -109,6 +109,7 @@ class QldbShell:
             try:
                 text = shell_session.prompt(self.prompt)
                 text = text.strip()
+                # Process escape sequences.
                 text = bytes(text, "utf-8").decode("unicode_escape")
                 if text:
                     self.onecmd(text)

--- a/qldbshell/qldb_shell.py
+++ b/qldbshell/qldb_shell.py
@@ -10,7 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
 # express or implied. See the License for the specific language governing 
 # permissions and limitations under the License.
-from ast import literal_eval
 import logging
 from textwrap import dedent
 

--- a/qldbshell/qldb_shell.py
+++ b/qldbshell/qldb_shell.py
@@ -10,7 +10,9 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
 # express or implied. See the License for the specific language governing 
 # permissions and limitations under the License.
+from ast import literal_eval
 import logging
+from shlex import quote
 from textwrap import dedent
 
 import prompt_toolkit
@@ -109,6 +111,7 @@ class QldbShell:
             try:
                 text = shell_session.prompt(self.prompt)
                 text = text.strip()
+                text = literal_eval(quote(text))
                 if text:
                     self.onecmd(text)
             except KeyboardInterrupt:

--- a/qldbshell/qldb_shell.py
+++ b/qldbshell/qldb_shell.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 from ast import literal_eval
 import logging
-from shlex import quote
 from textwrap import dedent
 
 import prompt_toolkit
@@ -111,7 +110,7 @@ class QldbShell:
             try:
                 text = shell_session.prompt(self.prompt)
                 text = text.strip()
-                text = literal_eval(quote(text))
+                text = bytes(text, "utf-8").decode("unicode_escape")
                 if text:
                     self.onecmd(text)
             except KeyboardInterrupt:

--- a/qldbshell/shell_utils.py
+++ b/qldbshell/shell_utils.py
@@ -4,7 +4,7 @@ from amazon.ion.simpleion import dumps
 
 
 def print_result(cursor: BufferedCursor):
-    results = map(lambda x: dumps(x, binary=False, indent=' ', omit_version_marker=True), cursor)
+    results = list(map(lambda x: dumps(x, binary=False, indent=' ', omit_version_marker=True), cursor))
     logging.info("\n" + str(',\n').join(results))
 
 

--- a/qldbshell/shell_utils.py
+++ b/qldbshell/shell_utils.py
@@ -4,8 +4,7 @@ from amazon.ion.simpleion import dumps
 
 
 def print_result(cursor: BufferedCursor):
-    results = list(map(lambda x: dumps(x, binary=False,
-                                       indent=' ', omit_version_marker=True), cursor))
+    results = map(lambda x: dumps(x, binary=False, indent=' ', omit_version_marker=True), cursor)
     logging.info("\n" + str(',\n').join(results))
 
 

--- a/qldbshell/shell_utils.py
+++ b/qldbshell/shell_utils.py
@@ -4,7 +4,8 @@ from amazon.ion.simpleion import dumps
 
 
 def print_result(cursor: BufferedCursor):
-    results = list(map(lambda x: dumps(x, binary=False, indent=' ', omit_version_marker=True), cursor))
+    results = list(map(lambda x: dumps(x, binary=False,
+                                       indent=' ', omit_version_marker=True), cursor))
     logging.info("\n" + str(',\n').join(results))
 
 

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -50,28 +50,28 @@ class TestQldbShell(TestCase):
         statement = "select * from another_table"
         mock_cli.default(statement)
 
-        mock_driver.get_session.assert_called_once_with()
-        assert mock_pooled_session.execute_lambda.call_count == 1
-        mock_pooled_session.close.assert_called_once_with()
+        mock_driver.get_session.assert_called()
+        assert mock_pooled_session.execute_lambda.call_count == 2
+        mock_pooled_session.close.assert_called()
 
     @patch('pyqldb.session.pooled_qldb_session.PooledQldbSession')
     @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')
     def test_default_client_error_session_closed(self, mock_driver, mock_pooled_session):
         mock_driver.get_session.return_value = mock_pooled_session
 
-        mock_invalid_session_error_message = {'Error': {'Code': 'InvalidSessionException',
-                                                        'Message': MOCK_MESSAGE}}
-        mock_pooled_session.execute_lambda.side_effect = ClientError(mock_invalid_session_error_message, MOCK_MESSAGE)
-
         mock_cli = QldbShell(None, mock_driver)
         mock_cli._in_session = True
         mock_cli._driver = mock_driver
 
+        mock_invalid_session_error_message = {'Error': {'Code': 'InvalidSessionException',
+                                                        'Message': MOCK_MESSAGE}}
+        mock_pooled_session.execute_lambda.side_effect = ClientError(mock_invalid_session_error_message, MOCK_MESSAGE)
+
         statement = "select * from another_table"
         mock_cli.default(statement)
 
-        mock_driver.get_session.assert_called_once_with()
-        mock_pooled_session.close.assert_called_once_with()
+        mock_driver.get_session.assert_called()
+        mock_pooled_session.close.assert_called()
 
     @patch('builtins.super')
     @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -100,8 +100,3 @@ class TestQldbShell(TestCase):
             mock.call('\''),
             mock.call('string_with_no_escape_sequences'),
         ])
-
-
-
-
-

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -84,4 +84,17 @@ class TestQldbShell(TestCase):
 
         self.assertRaises(SystemExit)
 
+    @patch('qldbshell.qldb_shell.QldbShell.do_exit')
+    @patch('qldbshell.qldb_shell.QldbShell._strip_text')
+    @patch('qldbshell.qldb_shell.QldbShell.onecmd')
+    @patch('qldbshell.qldb_shell.PromptSession')
+    @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')
+    def test_escape_sequences(self, mock_driver, mock_prompt_session, mock_onecmd, mock_strip_text, mock_do_exit):
+        mock_prompt_session.return_value = mock_prompt_session
+        mock_prompt_session.prompt.return_value = r'\\'
+        mock_strip_text.side_effect = ['', 'quit']
+        shell = QldbShell(None, mock_driver)
+        shell.cmdloop("test-ledger")
+        mock_onecmd.assert_called_with("\\")
+
 

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -16,7 +16,7 @@ from pyqldb.errors import SessionPoolEmptyError
 
 from qldbshell.errors import NoCredentialError
 from qldbshell.qldb_shell import QldbShell
-from unittest import TestCase
+from unittest import mock, TestCase
 from unittest.mock import patch
 import builtins
 
@@ -91,10 +91,17 @@ class TestQldbShell(TestCase):
     @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')
     def test_escape_sequences(self, mock_driver, mock_prompt_session, mock_onecmd, mock_strip_text, mock_do_exit):
         mock_prompt_session.return_value = mock_prompt_session
-        mock_prompt_session.prompt.return_value = r'\\'
-        mock_strip_text.side_effect = ['', 'quit']
+        mock_prompt_session.prompt.side_effect = [r'\\', r'\'', 'string_with_no_escape_sequences']
+        mock_strip_text.side_effect = ['', '', '', '', '', '', 'quit', 'quit']
         shell = QldbShell(None, mock_driver)
         shell.cmdloop("test-ledger")
-        mock_onecmd.assert_called_with("\\")
+        self.assertEquals(mock_onecmd.mock_calls, [
+            mock.call('\\'),
+            mock.call('\''),
+            mock.call('string_with_no_escape_sequences'),
+        ])
+
+
+
 
 

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -10,6 +10,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+import os
+import sys
+driver_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(driver_path, u"..", u"..",u"qldbshell", u"deps" ,u"amazon-qldb-driver-python"))
+
 from botocore.exceptions import EndpointConnectionError, ClientError, NoCredentialsError
 from pyqldb.driver.pooled_qldb_driver import PooledQldbDriver
 from pyqldb.errors import SessionPoolEmptyError
@@ -91,12 +96,12 @@ class TestQldbShell(TestCase):
     @patch('pyqldb.driver.pooled_qldb_driver.PooledQldbDriver')
     def test_escape_sequences(self, mock_driver, mock_prompt_session, mock_onecmd, mock_strip_text, mock_do_exit):
         mock_prompt_session.return_value = mock_prompt_session
-        mock_prompt_session.prompt.side_effect = [r'\\', r'\'', 'string_with_no_escape_sequences']
+        mock_prompt_session.prompt.side_effect = [r'\\', r'\'', 'string with no escape sequences']
         mock_strip_text.side_effect = ['', '', '', '', '', '', 'quit', 'quit']
         shell = QldbShell(None, mock_driver)
         shell.cmdloop("test-ledger")
         self.assertEquals(mock_onecmd.mock_calls, [
             mock.call('\\'),
             mock.call('\''),
-            mock.call('string_with_no_escape_sequences'),
+            mock.call('string with no escape sequences'),
         ])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
> Currently when a user uses the shell and inputs a statement containing escape sequences, the input is saved into a string variable which does not process the escape sequence. This leads to erroneous behaviour which can potentially save incorrect data in QLDB. The fix is to convert the string to bytes and decode with `unicode_escape`.
> 
> Before fix:
> User inputs: `INSERT INTO Json {'foo': 'test\\123'}` and QLDB saves record as 
> ```
> {
>    "foo":"test\\123"
> }
> ```
> 
> After fix:
> User inputs: `INSERT INTO Json {'foo': 'test\\123'}` and QLDB saves record as 
> ```
> {
>    "foo":"test\123"
> }
> ```
> 
> For more information:
> https://stackoverflow.com/questions/54410812/how-do-you-input-escape-sequences-in-python
> https://stackoverflow.com/questions/4020539/process-escape-sequences-in-a-string-in-python
> 
> Also in this PR, I fixed two of the failing unit tests (they were failing before I applied the escape sequence support.
> 
> Verified this fix by running unit tests, manually running through QLDB console guide, and testing insert statements containing escape sequences.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
