### PR TITLE
Support multiline inputs with bags [#26]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,16 +341,6 @@ dependencies = [
 
 [[package]]
 name = "dirs-next"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
@@ -394,6 +384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +431,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures"
@@ -801,14 +807,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.18.0"
+name = "nibble_vec"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -1039,6 +1054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1199,7 @@ checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
 dependencies = [
  "async-trait",
  "chrono",
- "dirs-next 2.0.0",
+ "dirs-next",
  "futures",
  "hyper",
  "serde",
@@ -1252,17 +1277,21 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+checksum = "b9e1b597fcd1eeb1d6b25b493538e5aa19629eb08932184b85fef931ba87e893"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-next 1.0.2",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "dirs-next",
+ "fs2",
  "libc",
  "log",
  "memchr",
  "nix",
+ "radix_trie",
  "scopeguard",
+ "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -1409,6 +1438,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 amazon-qldb-driver = { git = "https://github.com/awslabs/amazon-qldb-driver-rust", branch = "main" }
 rusoto_core = "0.46.0"
 rusoto_qldb_session = "0.46.0"
-rustyline = "6.2.0"
+rustyline = "8.0.0"
 dirs = "3.0.1"
 log = "0.4.11"
 fern = "0.6.0"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,4 @@
-use crate::repl_helper::ReplHelper;
+use crate::repl_helper::QldbHelper;
 use dirs;
 use rustyline::error::ReadlineError;
 use rustyline::{Config, Editor};
@@ -33,12 +33,12 @@ pub mod testing {
         pub(crate) pending: Vec<String>,
         output: Vec<String>,
         warn: Vec<String>,
-        debug: Vec<String>
+        debug: Vec<String>,
     }
 
     #[derive(Default)]
     pub struct TestUi {
-        inner: RefCell<TestUiInner>
+        inner: RefCell<TestUiInner>,
     }
 
     impl Ui for TestUi {
@@ -79,38 +79,38 @@ pub mod testing {
             self.inner.borrow_mut().debug.push(str.to_string());
         }
     }
-
 }
 
 struct UiInner {
-    rl: Editor<ReplHelper>,
+    editor: Editor<QldbHelper>,
     prompt: String,
     pending_actions: Vec<String>,
 }
 
-/// Encapsulates handling of user input. In particular, we use readline to handle keyboard input (capturing lines, but also history and Emacs/Vi bindings) and support 'sending; multiple;
-/// inputs'. We also capture history for uparrow or Ctrl-R replay.
+/// Encapsulates handling of user input. In particular, we use readline to
+/// handle keyboard input (capturing lines, but also history and Emacs/Vi
+/// bindings) and support 'sending; multiple; inputs'. We also capture history
+/// for uparrow or Ctrl-R replay.
 ///
-/// This type users interior mutability because the [`QldbDriver::transact`] method takes a `Fn` arg (not `FnMut`) so that retries don't have side-effects. However, we disable retries and
-/// thus don't care about the side-effects (e.g. of saving history).
+/// This type users interior mutability because the [`QldbDriver::transact`]
+/// method takes a `Fn` arg (not `FnMut`) so that retries don't have
+/// side-effects. However, we disable retries and thus don't care about the
+/// side-effects (e.g. of saving history).
 pub(crate) struct ConsoleUi {
     inner: RefCell<UiInner>,
 }
 
 impl ConsoleUi {
     pub(crate) fn new() -> ConsoleUi {
-        let config = Config::builder() // FIXME: customize :)
-            .build();
-        let mut rl = Editor::with_config(config);
-        rl.set_helper(Some(ReplHelper::default()));
+        let mut editor = create_editor();
 
         if let Some(p) = history_path() {
-            rl.load_history(&p).keep_going();
+            editor.load_history(&p).keep_going();
         }
 
         ConsoleUi {
             inner: RefCell::new(UiInner {
-                rl,
+                editor,
                 prompt: "> ".to_owned(),
                 pending_actions: vec![],
             }),
@@ -124,11 +124,10 @@ impl ConsoleUi {
     // 3. Also don't want to load/persist history
     // 4. exit is awful
     pub(crate) fn new_for_script(script: &str) -> io::Result<ConsoleUi> {
-        let config = Config::builder().build();
-        let mut rl = Editor::with_config(config);
-        rl.set_helper(Some(ReplHelper::default()));
+        let editor = create_editor();
 
-        // We start the pending actions by reading the input, splitting it up into new lines..
+        // We start the pending actions by reading the input, splitting it up
+        // into new lines..
         let mut pending_actions: Vec<_> = script
             .lines()
             .map(|line| line.split(";").map(|it| it.trim().to_owned()))
@@ -140,12 +139,20 @@ impl ConsoleUi {
 
         Ok(ConsoleUi {
             inner: RefCell::new(UiInner {
-                rl,
+                editor,
                 prompt: "".to_owned(),
                 pending_actions,
             }),
         })
     }
+}
+
+fn create_editor() -> Editor<QldbHelper> {
+    let config = Config::builder() // FIXME: customize :)
+        .build();
+    let mut editor = Editor::with_config(config);
+    editor.set_helper(Some(QldbHelper::default()));
+    editor
 }
 
 impl Ui for ConsoleUi {
@@ -155,11 +162,14 @@ impl Ui for ConsoleUi {
 
     /// Prompts the user for input or returns the next pending action.
     ///
-    /// Users can enter multiple commands like 'foo; bar'. These commands will be processed as if first 'foo' was entered and then 'bar', except that errors MUST halt the chain (see
-    /// [`clear_pending`]).
+    /// Users can enter multiple commands like 'foo; bar'. These commands will
+    /// be processed as if first 'foo' was entered and then 'bar', except that
+    /// errors MUST halt the chain (see [`clear_pending`]).
     ///
-    /// Note that the history will contain the actual input ('foo; bar' not 'foo' & 'bar'). Similarly, we trim the strings such that 'foo;bar' and 'foo; bar' are treated identically (but the
-    /// history will have the raw input).
+    /// Note that the history will contain the actual input ('foo; bar' not
+    /// 'foo' & 'bar'). Similarly, we trim the strings such that 'foo;bar' and
+    /// 'foo; bar' are treated identically (but the history will have the raw
+    /// input).
     fn user_input(&self) -> Result<String, ReadlineError> {
         let mut inner = self.inner.borrow_mut();
 
@@ -168,9 +178,9 @@ impl Ui for ConsoleUi {
         }
 
         let prompt = inner.prompt.clone();
-        match inner.rl.readline(&prompt) {
+        match inner.editor.readline(&prompt) {
             Ok(line) => {
-                inner.rl.add_history_entry(line.as_str());
+                inner.editor.add_history_entry(line.as_str());
                 inner.pending_actions = line.split(";").map(|it| it.trim().to_owned()).collect();
                 inner.pending_actions.reverse();
                 drop(inner);
@@ -186,7 +196,7 @@ impl Ui for ConsoleUi {
     }
 
     fn println(&self, str: &str) {
-        println!("{}",str);
+        println!("{}", str);
     }
 
     fn newline(&self) {
@@ -202,14 +212,14 @@ impl Ui for ConsoleUi {
     }
 
     fn debug(&self, str: &str) {
-        debug!("{}",str);
+        debug!("{}", str);
     }
 }
 
 impl Drop for ConsoleUi {
     fn drop(&mut self) {
         if let Some(p) = history_path() {
-            self.inner.borrow_mut().rl.save_history(&p).keep_going();
+            self.inner.borrow_mut().editor.save_history(&p).keep_going();
         }
     }
 }


### PR DESCRIPTION
Upgrade rustyline from 6.2 -> 8.0 and change the Validator to suppport
bags.

The Validator is responsible for looking at a line and determining if it
is `Incomplete` or not. The previous implementation checked for
incomplete lines using `([{`, now we also check for bags (`<<`).

This was a little involved because we now need our own Validator (can't
use the one out of the box) and we also needed more fancy stuff to
support multi-character structures.

The net effect of this change is if you type

    qldb> begin
    qldb(tx: 7tiNWPtCr0V586d6es7wGJ)> INSERT INTO Person <<[press ENTER]

then you will be able to continue on the next line.

Note that in #26, the example is `INSERT INTO Person[press ENTER]` which
will not work. To make that case work, we'd need to parse the PartiQL
and note that the statement was not complete. (This example *does* work
if the text is pasted in, however.)

I think the next reasonable step would be to support explicit multiline
input by using a delimiter such as `;`. That would allow for fine-grain
control of submission without getting into parsing.

*Issue #, if available:* #26

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
