### PR TITLE
Use default prompt if user does not have default_config.toml set up

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -107,7 +107,10 @@ impl Environment {
 
     pub fn apply_config(&mut self, config: &Config) {
         self.auto_commit.apply(config.auto_commit, Setter::Config);
-        self.prompt.apply(config.ui.prompt.clone(), Setter::Config);
+
+        if let Some(ui) = &config.ui {
+            self.prompt.apply(Some(ui.prompt.clone()), Setter::Config);
+        }
     }
 
     pub fn apply_cli(&mut self, opt: &Opt) {
@@ -132,13 +135,13 @@ impl Environment {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct UiTomlTable {
-    prompt: Option<String>,
+    prompt: String,
 }
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct Config {
     auto_commit: Option<bool>,
-    ui: UiTomlTable,
+    ui: Option<UiTomlTable>,
 }
 
 impl Config {


### PR DESCRIPTION
Fixing the following error when the user does not have their `default_config.toml` set up:

``` 
justingossett@Justins-MBP amazon-qldb-shell % cargo run -- --ledger test-ledger
    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
     Running `target/debug/qldb --ledger test-ledger`
qldb shell error: unable to load config at /Users/justingossett/Library/Application Support/qldbshell/default_config.toml: missing field `ui`
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
