### PR TITLE
Start to configure the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.0.0-alpha5] - [Unreleased]
 
- * The prompt can now be configured in the config file with `$LEDGER` and `$REGION`. e.g: `prompt="$REGION/$LEDGER >"`
+ * The prompt can now be configured in the config file with `$LEDGER` and `$REGION`. e.g: `prompt="$REGION/$LEDGER > "`
 
 ## [2.0.0-alpha4] - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.0.0-alpha5] - [Unreleased]
 
+ * The prompt can now be configured in the config file with `$LEDGER` and `$REGION`. e.g: `prompt="$REGION/$LEDGER >"`
 
 ## [2.0.0-alpha4] - 2021-04-23
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub async fn run() -> Result<()> {
     let mut env = Environment::new();
     env.apply_config(&config);
     env.apply_cli(&opt)?;
-    rusoto_driver::health_check_start_session(&env).await?;
+    rusoto_driver::health_check_start_session(&mut env).await?;
     let mut runner = Runner::new_with_env(env, &opt.execute).await?;
     runner.start().await
 }
@@ -58,10 +58,10 @@ impl Deps<QldbSessionClient> {
     // Production use: builds a real set of dependencies usign the Rusoto client
     // and ConsoleUi.
     async fn new_with_env(
-        env: Environment,
+        mut env: Environment,
         execute: &Option<ExecuteStatementOpt>,
     ) -> Result<Deps<QldbSessionClient>> {
-        let driver = rusoto_driver::build_driver(&env).await?;
+        let driver = rusoto_driver::build_driver(&mut env).await?;
 
         let ui = match execute {
             Some(ref e) => {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -172,6 +172,10 @@ impl Environment {
 
         Ok(())
     }
+
+    pub fn set_region(&mut self, region: String, setter: Setter) {
+        self.region.apply_opt(&Some(region), setter)
+    }
 }
 
 #[derive(Debug, StructOpt, Default)]


### PR DESCRIPTION
Made the `$LEDGER` and `$REGION` settable on the prompt, which can only be read from Config for now. I think the ownership model is wrong, but not sure how to resolve it yet. Submitting to be educated! :)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
