### PR TITLE
Reuse the healthcheck client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Changed
   
   * File logging now uses bunyan at maximum log level. 
+  * The initial healthcheck client becomes the driver.
+    - This means the initial HTTPS connection and credential loads can be reused.
 
 ## [2.0.0-alpha7] - 2021-05-05
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -43,12 +43,13 @@ where
 }
 
 impl Runner<QldbSessionClient> {
-    pub(crate) async fn new_with_env(
+    pub(crate) async fn new(
+        client: QldbSessionClient,
         env: Environment,
         execute: &Option<ExecuteStatementOpt>,
     ) -> Result<Runner<QldbSessionClient>> {
         Ok(Runner {
-            deps: Deps::new_with_env(env, execute).await?,
+            deps: Deps::new(client, env, execute).await?,
             current_transaction: None,
         })
     }


### PR DESCRIPTION
In a previous commit I made it way easier to trace the underlying
workings of the shell. I found that the first command had to get a new
connection - weird!

Obviously, this is because we had a new client for the healthcheck and
driver. So the healthcheck made a request, then we shut down that pool,
then made another. Now, we share the client!

This is especially nice for profile based clients because credentials
are now shared between clients too!

I also made a change to cleanup the healthcheck session.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
