### PR TITLE
Implement --status and --ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.0-alpha12] - [Unreleased]
+
+### Added
+
+- Added `\ping` which prints the round trip time.
+- Added `\status` which prints the current ledger/region/version.
+
 ## [2.0.0-alpha11] - 2021-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "itertools",
  "pest",
  "pest_derive",
+ "reqwest",
  "rusoto_core",
  "rusoto_qldb_session",
  "rustyline",
@@ -550,6 +551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +609,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -761,6 +786,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +894,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -875,6 +926,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +947,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -934,6 +1008,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
@@ -1052,6 +1132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1157,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1185,10 +1289,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1307,6 +1438,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -1514,6 +1651,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -1790,6 +1961,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2224,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2398,20 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2391,6 +2612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2652,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2441,6 +2670,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2531,6 +2772,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ bigdecimal = "0.2.0"
 smallvec = "1.6.1"
 atty = "0.2.14"
 url = "2.2.2"
+reqwest = "0.11.3"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -231,9 +231,12 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
 
     pub(crate) async fn handle_status(&self) -> Result<()> {
         // TODO: Return latency information from recent commands if we're able to capture it.
-        self.deps.ui.println(&format!("Current region: {}", self.deps.env.region().value.name()));
-        self.deps.ui.println(&format!("Current ledger: {}", self.deps.driver.ledger_name()));
-        self.deps.ui.println(&format!("Shell version: {}", env!("CARGO_PKG_VERSION")));
+        self.deps.ui.println(&format!(
+            "Region: {}, Ledger: {}, Shell version: {}",
+            self.deps.env.region().value.name(),
+            self.deps.driver.ledger_name(),
+            env!("CARGO_PKG_VERSION")
+        ));
         Ok(())
     }
 
@@ -247,9 +250,9 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
 
         let start = Instant::now();
         let response = reqwest::get(request_url).await?;
-        let total_time = Instant::now().duration_since(start).as_millis();
         let status_code = response.status();
         let response_body = response.text().await?;
+        let total_time = Instant::now().duration_since(start).as_millis();
 
         if status_code == 200 && response_body == "healthy" {
             self.deps.ui.println(&format!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -249,15 +249,12 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
                 ));
             }
             Err(_e) => {
-                self.deps.ui.println(&format!(
-                    "Connection status: Unavailable"
-                ));
+                self.deps.ui.println(&format!("Connection status: Unavailable"));
             }
         }
 
-        self.deps.ui.println(&format!("Connected Ledger: {}", self.deps.driver.ledger_name()));
-        const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-        self.deps.ui.println(&format!("Client version: {}", VERSION));
+        self.deps.ui.println(&format!("Current Ledger: {}", self.deps.driver.ledger_name()));
+        self.deps.ui.println(&format!("Client version: {}", env!("CARGO_PKG_VERSION")));
         Ok(())
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -253,7 +253,7 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
             }
         }
 
-        self.deps.ui.println(&format!("Current Ledger: {}", self.deps.driver.ledger_name()));
+        self.deps.ui.println(&format!("Current ledger: {}", self.deps.driver.ledger_name()));
         self.deps.ui.println(&format!("Client version: {}", env!("CARGO_PKG_VERSION")));
         Ok(())
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -239,12 +239,11 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
 
     pub(crate) async fn handle_ping(&self) -> Result<()> {
         let region = self.deps.env.region().value.name().to_string();
-        let mut request_url = Url::parse(&format!("https://session.qldb.{}.amazonaws.com/ping", region))?;
 
-        let qldb_session_endpoint = self.deps.env.qldb_session_endpoint().value;
-        if qldb_session_endpoint.is_some() {
-            request_url = qldb_session_endpoint.unwrap().join("ping")?;
-        }
+        let request_url = match self.deps.env.qldb_session_endpoint().value {
+            Some(url) => url.join("ping")?,
+            None => Url::parse(&format!("https://session.qldb.{}.amazonaws.com/ping", region))?
+        };
 
         let start = Instant::now();
         let response = reqwest::get(request_url).await?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -169,6 +169,7 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
             "commit" => self.handle_commit().await?,
             "env" => self.handle_env(),
             "show tables" => self.handle_show_tables().await?,
+            "ping" => self.handle_ping().await?,
             "status" => self.handle_status().await?,
             "use" => return Ok(TickFlow::Restart), // TODO: implement
             _ => self.handle_complex_command(line)?,
@@ -229,6 +230,14 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
     }
 
     pub(crate) async fn handle_status(&self) -> Result<()> {
+        // TODO: Return latency information from recent commands if we're able to capture it.
+        self.deps.ui.println(&format!("Current region: {}", self.deps.env.region().value.name()));
+        self.deps.ui.println(&format!("Current ledger: {}", self.deps.driver.ledger_name()));
+        self.deps.ui.println(&format!("Shell version: {}", env!("CARGO_PKG_VERSION")));
+        Ok(())
+    }
+
+    pub(crate) async fn handle_ping(&self) -> Result<()> {
         let region = self.deps.env.region().value.name().to_string();
         let mut request_url = Url::parse(&format!("https://session.qldb.{}.amazonaws.com/ping", region))?;
 
@@ -251,10 +260,6 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
         } else {
             self.deps.ui.println(&format!("Connection status: Unavailable"));
         }
-
-        self.deps.ui.println(&format!("Current region: {}", self.deps.env.region().value.name()));
-        self.deps.ui.println(&format!("Current ledger: {}", self.deps.driver.ledger_name()));
-        self.deps.ui.println(&format!("Shell version: {}", env!("CARGO_PKG_VERSION")));
         Ok(())
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -254,6 +254,10 @@ When your transaction is complete, enter 'commit' or 'abort' as appropriate."#,
                 ));
             }
         }
+
+        self.deps.ui.println(&format!("Connected Ledger: {}", self.deps.driver.ledger_name()));
+        const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+        self.deps.ui.println(&format!("Client version: {}", VERSION));
         Ok(())
     }
 }

--- a/src/settings/environment.rs
+++ b/src/settings/environment.rs
@@ -175,7 +175,7 @@ impl Environment {
         inner.profile.clone()
     }
 
-    fn _qldb_session_endpoint(&self) -> Setting<Option<Url>> {
+    pub(crate) fn qldb_session_endpoint(&self) -> Setting<Option<Url>> {
         let inner = self.inner.lock().unwrap();
         inner.qldb_session_endpoint.clone()
     }


### PR DESCRIPTION
*Issue #, if available:*
#43 

*Description of changes:*
* Implement `\ping` command which will send a HTTP GET `/ping` request to QLDB and check if the service responds. If it is responsive, the output will be:
   ```
   Connection status: Connected, roundtrip-time: 424ms 
   ```

  If it was not successful, the output will be:
  ```
  Connection status: Unavailable
  ```

* Implement the `\status` command which will return the current region, ledger, and shell version.
    ```
    Current region: us-east-1
    Current ledger: vehicle-registration
    Shell version: 2.0.0-alpha10
    ```


For reference, I checked MySQL shell and this is their response when calling `\status`
```
MySQL Shell version 8.0.25

Connection Id:                9
Current schema:               
Current user:                 root@localhost
SSL:                          Cipher in use: TLS_AES_256_GCM_SHA384 TLSv1.3
Using delimiter:              ;
Server version:               8.0.25 MySQL Community Server - GPL
Protocol version:             Classic 10
Client library:               8.0.25
Connection:                   localhost via TCP/IP
TCP port:                     3306
Server characterset:          utf8mb4
Schema characterset:          utf8mb4
Client characterset:          utf8mb4
Conn. characterset:           utf8mb4
Result characterset:          utf8mb4
Compression:                  Disabled
Uptime:                       1 hour 21 min 15.0000 sec

Threads: 2  Questions: 54  Slow queries: 0  Opens: 135  Flush tables: 3  Open tables: 56  Queries per second avg: 0.011
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
