### PR TITLE
Add dependabot automerge

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,30 @@
+name: "Dependabot Automerge"
+
+on:
+  workflow_run:
+    workflows: ["CI Build"]
+    types: 
+      - completed
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/github-script@v3
+        env:
+          pull_request_number: ${{ toJSON(github.event.workflow_run.pull_requests[0].number) }}
+        with:
+          script: |
+            github.pulls.createReview({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: ${{env.pull_request_number}},
+              event: 'APPROVE'
+            })
+            github.pulls.merge({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: ${{env.pull_request_number}},
+            })
+          github-token: ${{secrets.WRITE_TOKEN}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a GitHub actions file which will run after a Dependabot PR's successful build. 

This action will approve and merge the PR using a user's access token. The reason is we have to specify a person's access token is because the `rust` branch has restriction on who can push to the branch so the Github bot is unable to push.

Currently the access token is set to mine.


Tested on my [fork](https://github.com/byronlin13/amazon-qldb-shell/pull/5). 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
