### PR TITLE
Update release GitHub action to sign MSI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
             bin: qldb
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          role-duration-seconds: 1800
+          
       - name: Env Variable Setup
         if: matrix.os == 'windows-latest'
         run: |
@@ -127,7 +136,27 @@ jobs:
           
           cd target/wix
           mv amazon_qldb_shell*.msi ../../$release_name.msi
-        
+    
+          cd ../../
+          $complete_file_name = $release_name + ".msi"
+          
+          # Push unsigned MSI to S3
+          $put_object_response=( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body $complete_file_name --acl bucket-owner-full-control ) | ConvertFrom-Json 
+          $version_id = $put_object_response.VersionId
+
+          # Wait 5 seconds for job ID tag to be populated in S3 object
+          Start-Sleep -s 5
+          
+          # Get job ID
+          $get_object_tagging_response=( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id $version_id ) | ConvertFrom-Json
+          $job_id = $get_object_tagging_response.TagSet[0].Value         
+          
+          # Poll signed S3 bucket to see if the signed artifact is there
+          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-$job_id
+          
+          # Get signed MSI from S3
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-$job_id $complete_file_name
+          
       - name: Publish
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           
           cd target/wix
           mv amazon_qldb_shell*.msi ../../$release_name.msi
-    
+        
           cd ../../
           $complete_file_name = $release_name + ".msi"
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,12 +144,29 @@ jobs:
           $put_object_response=( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body $complete_file_name --acl bucket-owner-full-control ) | ConvertFrom-Json 
           $version_id = $put_object_response.VersionId
 
-          # Wait 5 seconds for job ID tag to be populated in S3 object
-          Start-Sleep -s 5
+          $job_id = ""
+          $num_of_retries_to_get_job_id = 3
           
-          # Get job ID
-          $get_object_tagging_response=( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id $version_id ) | ConvertFrom-Json
-          $job_id = $get_object_tagging_response.TagSet[0].Value         
+          # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
+          # Will sleep for 5 seconds between retries.
+          for (($i = 0); $i -lt $num_of_retries_to_get_job_id; $i++)
+          {
+              $get_object_tagging_response=( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id $version_id ) | ConvertFrom-Json
+              $id = $get_object_tagging_response.TagSet[0].Value       
+                
+              if ($id)
+              {
+                  $job_id = $id
+                  break
+              }
+              Start-Sleep -s 5
+          }
+
+          if ($job_id -eq "")
+          {
+             echo "Exiting because unable to retrieve job ID"
+             exit 1
+          }
           
           # Poll signed S3 bucket to see if the signed artifact is there
           aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-$job_id


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is to demonstrate the integration of the QLDB Rust shell and the AWS signer service(for security reviewer).

We created a GitHub action to automate the signing of MSI

The high level workflow is:

1. Push the unsigned MSI into designated unsigned S3 bucket (this will trigger the signing job)
2. Poll the signed bucket to see if the signed MSI appears
3. Fetch the signed MSI from designated signed S3 bucket

Tested successfully with a test profile provided by Signer team on my [fork](https://github.com/byronlin13/amazon-qldb-shell/actions/runs/1036249137)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
