### PR TITLE
Abort autocommit statements with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixed
 
 - A bug where `ui.format` option in config file would not work (fixes #132).
+- Fixed a case where an invalid statement could cause the shell to hang in
+  autocommit mode (#142).
 
 ## [2.0.0-alpha13] - 2021-07-28
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -105,9 +105,10 @@ where
         }
         self.handle_start_transaction();
         if let Err(e) = self.handle_partiql(line).await {
-            // By dropping the current transaction, the input channel will be
-            // closed which ends the transaction.
-            self.current_transaction.take();
+            // If we got an error, the transaction might still be open if the
+            // error was not fatal to the transaction. So, we should send an
+            // abort.
+            let _ = self.handle_abort().await; // ignore any error calling abort()
             Err(e)?
         }
         self.handle_commit().await?;


### PR DESCRIPTION
Before this commit, a single statement transaction (in autocommit mode)
might result in a hang, as reported in #142.

The reason for this is that not all errors end the transaction on the
server. So, for example, `select * from foo` might throw an error if
there is no table "foo", but the *transaction is still open*.

This means that the session goes back into the pool and the next
transaction attempt fails, by calling StartTransaction where one was
already open on that session.

There should be defense in depth in the pool implementation to prevent
the hang. However, this is the simplest change to fix the bug.