### PR TITLE
Rename application name from qldb-shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - A bug where `ui.format` option in config file would not work (fixes #132).
 - Fixed a case where an invalid statement could cause the shell to hang in
   autocommit mode (#142).
+- Program name in `--help` now matches the binary name.
 
 ## [2.0.0-alpha13] - 2021-07-28
 

--- a/src/settings/command_line.rs
+++ b/src/settings/command_line.rs
@@ -9,10 +9,7 @@ use url::Url;
 use crate::error::{usage_error, ShellError};
 
 #[derive(Debug, StructOpt, Default)]
-#[structopt(
-    name = "qldb-shell",
-    about = "A shell for interacting with Amazon QLDB."
-)]
+#[structopt(name = "qldb", about = "A shell for interacting with Amazon QLDB.")]
 pub struct Opt {
     #[structopt(short, long = "--region")]
     pub region: Option<String>,


### PR DESCRIPTION
When running `--help`, the program name was printed to be `qldb-shell`,
which doesn't match the new binary name.