### PR TITLE
fix case where no credentials are found

### DIFF
--- a/src/awssdk_driver.rs
+++ b/src/awssdk_driver.rs
@@ -140,7 +140,8 @@ async fn build_client(env: &Environment) -> Result<QldbSessionSdk<DynConnector>>
         Some(p) => CredentialProvider::Profile(p),
         None => CredentialProvider::Default(DefaultCredentialsProvider::new()?),
     };
-    let creds = credentials::from_rusoto(rusoto_provider).await?;
+    let creds = credentials::from_rusoto(rusoto_provider);
+
     let conf = Config::builder()
         .region(env.current_region())
         .credentials_provider(creds);

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,77 +1,40 @@
-use std::io;
-use std::sync::mpsc::sync_channel;
-use std::sync::mpsc::Receiver as SyncReceiver;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::thread::JoinHandle;
-
-use anyhow::Result;
-use aws_auth::provider::{CredentialsError, ProvideCredentials};
+use aws_auth::provider::AsyncProvideCredentials;
+use aws_auth::provider::BoxFuture;
+use aws_auth::provider::CredentialsError;
+use aws_auth::provider::CredentialsResult;
 use aws_auth::Credentials;
 use rusoto_core::credential::ProvideAwsCredentials as RusotoProvider;
-use tokio::runtime::Builder;
-use tokio::sync::mpsc::{channel, Sender};
 
-pub(crate) struct RusotoCredentialProvider {
-    bridge: AsyncBridge,
+pub(crate) struct RusotoCredentialProvider<P: RusotoProvider + Send + Sync + 'static> {
+    rusoto: P,
 }
 
-struct AsyncBridge {
-    tx: Sender<()>,
-    rx: Arc<Mutex<SyncReceiver<Result<Credentials, CredentialsError>>>>,
-    _handle: JoinHandle<io::Result<()>>, // stored for cancellation purposes
-}
-
-pub(crate) async fn from_rusoto<P>(rusoto: P) -> Result<RusotoCredentialProvider>
+pub(crate) fn from_rusoto<P>(rusoto: P) -> RusotoCredentialProvider<P>
 where
     P: RusotoProvider + Send + Sync + 'static,
 {
-    let (wake, mut req) = channel(1);
-    let (res, credentials) = sync_channel(1);
-
-    let handle = thread::spawn(|| {
-        let rt = Builder::new_current_thread().build()?;
-        rt.block_on(async move {
-            loop {
-                if let None = req.recv().await {
-                    break;
-                }
-                let credentials = match rusoto.credentials().await {
-                    Ok(credentials) => Ok(Credentials::from_keys(
-                        credentials.aws_access_key_id(),
-                        credentials.aws_secret_access_key(),
-                        credentials.token().to_owned(),
-                    )),
-                    Err(err) => Err(CredentialsError::Unhandled(Box::new(err))),
-                };
-                if let Err(_) = res.send(credentials) {
-                    break;
-                }
-            }
-        });
-
-        Ok(())
-    });
-
-    let bridge = AsyncBridge {
-        tx: wake,
-        rx: Arc::new(Mutex::new(credentials)),
-        _handle: handle,
-    };
-
-    Ok(RusotoCredentialProvider { bridge })
+    RusotoCredentialProvider { rusoto }
 }
 
-impl ProvideCredentials for RusotoCredentialProvider {
-    fn provide_credentials(&self) -> Result<Credentials, CredentialsError> {
-        self.bridge
-            .tx
-            .try_send(())
-            .expect("the credentials task should never crash");
-        // This doesn't work because (I think) the spawned future never wakes
-        // up.
-        let res = self.bridge.rx.lock().expect("mutex is never poisoned");
-        res.recv()
-            .expect("credentials (or an error) should always come back")
+impl<P> AsyncProvideCredentials for RusotoCredentialProvider<P>
+where
+    P: RusotoProvider + Send + Sync + 'static,
+{
+    fn provide_credentials<'a>(&'a self) -> BoxFuture<'a, CredentialsResult>
+    where
+        Self: 'a,
+    {
+        let fut = async move {
+            match self.rusoto.credentials().await {
+                Ok(credentials) => Ok(Credentials::from_keys(
+                    credentials.aws_access_key_id(),
+                    credentials.aws_secret_access_key(),
+                    credentials.token().to_owned(),
+                )),
+                Err(err) => Err(CredentialsError::Unhandled(Box::new(err))),
+            }
+        };
+
+        Box::pin(fut)
     }
 }


### PR DESCRIPTION
The rusoto credentials bridge was added before the awssdk supported
async providers. It had a bug, causing a bad user message as
demonstrated in #166. To fix the bug, we move to the new async interface
which also cleans up some code.

Note that the overall experience is still not wonderful because the
default chain tries to connect to localhost (to support instance
metadata credentials). This has a 30s timeout. To fix this, we'll need
to either workaround the behavior in rusoto or wait for the awssdk to
provide in-crate providers.