### PR TITLE
Write errors to stderr

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -123,7 +123,7 @@ where
                 Ok(TickFlow::Again) => {}
                 Ok(TickFlow::Exit) => return Ok(ProgramFlow::Exit),
                 Ok(TickFlow::Restart) => return Ok(ProgramFlow::Restart),
-                Err(e) => self.deps.ui.println(&format!("{}", e)),
+                Err(e) => self.deps.ui.eprintln(&format!("{}", e)),
             }
         }
     }
@@ -189,7 +189,7 @@ where
             "quit" | "exit" => {
                 return Ok(TickFlow::Exit);
             }
-            "start transaction" | "begin" => self.handle_start_transaction(),
+            "start transaction" | "begin" => self.handle_start_transaction()?,
             "abort" => self.handle_abort().await?,
             "commit" => self.handle_commit().await?,
             "env" => self.handle_env(),

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -103,7 +103,7 @@ where
                 Start a transaction with 'start transaction' or 'begin'"
             )))?;
         }
-        self.handle_start_transaction();
+        self.handle_start_transaction()?;
         if let Err(e) = self.handle_partiql(line).await {
             // If we got an error, the transaction might still be open if the
             // error was not fatal to the transaction. So, we should send an
@@ -115,14 +115,14 @@ where
         Ok(TickFlow::Again)
     }
 
-    pub(crate) fn handle_start_transaction(&mut self) {
+    pub(crate) fn handle_start_transaction(&mut self) -> Result<()> {
         if let Some(_) = self.current_transaction {
-            self.deps.ui.println("Transaction already open");
-            return;
+            return Err(QldbShellError::UsageError(format!("Transaction already open")))?;
         }
 
         let new_tx = new_transaction(self.deps.driver.clone());
         self.current_transaction.replace(new_tx);
+        Ok(())
     }
 
     pub(crate) async fn handle_partiql(&mut self, line: &str) -> Result<TickFlow> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,6 +18,8 @@ pub(crate) trait Ui {
 
     fn println(&self, str: &str);
 
+    fn eprintln(&self, str: &str);
+
     fn newline(&self);
 
     fn print(&self, str: &str);
@@ -76,6 +78,10 @@ pub mod testing {
         }
 
         fn println(&self, str: &str) {
+            self.inner.borrow_mut().output.push(str.to_string());
+        }
+
+        fn eprintln(&self, str: &str) {
             self.inner.borrow_mut().output.push(str.to_string());
         }
 
@@ -214,6 +220,10 @@ impl Ui for ConsoleUi {
 
     fn println(&self, str: &str) {
         println!("{}", str);
+    }
+
+    fn eprintln(&self, str: &str) {
+        eprintln!("{}", str);
     }
 
     fn newline(&self) {


### PR DESCRIPTION
This moves error messages to stderr, and standardizes an error
emitted by `handle_start_transaction`.

*Issue , if available:*
#154 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
