### PR TITLE
Update workflow target branch from `rust` to `main` after release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     commit-message:
       prefix: "cargo"
     open-pull-requests-limit: 10
-    target-branch: "rust"
+    target-branch: "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: CI Release
 on:
   push:
     branches:
-      - rust
+      - main
     tags:
       - "v*.*.*"
   pull_request:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ rust ]
+    branches: [ main ]
   pull_request:
-    branches: [ rust ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
#156 
*Description of changes:*
Update target branch from `rust` to `main` after we rename the `rust` branch to `main` and change it to default branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
