### PR TITLE
Use personal access token for automerge

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -28,4 +28,4 @@ jobs:
               repo: context.payload.repository.name,
               pull_number: ${{env.pull_request_number}},
             })
-          github-token: ${{github.token}}
+          github-token: ${{secrets.WRITE_TOKEN}}


### PR DESCRIPTION
*Description of changes:*

Use personal access token to merge the dependabot PRs because the `main` branch has restriction on who can push to the branch so the Github bot is unable to push. Currently the access token is set to mine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
