### PR TITLE
Upgrade sdk and ion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "amazon-qldb-driver"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/amazon-qldb-driver-rust?branch=main#16003e5246432d70cf268a3c937f7c4c454029ea"
+source = "git+https://github.com/awslabs/amazon-qldb-driver-rust?branch=main#31545606f826cb367a8cbec846fc03b56ee71e4b"
 dependencies = [
  "amazon-qldb-driver-core",
  "tokio",
@@ -23,20 +23,20 @@ dependencies = [
 [[package]]
 name = "amazon-qldb-driver-core"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/amazon-qldb-driver-rust?branch=main#16003e5246432d70cf268a3c937f7c4c454029ea"
+source = "git+https://github.com/awslabs/amazon-qldb-driver-rust?branch=main#31545606f826cb367a8cbec846fc03b56ee71e4b"
 dependencies = [
  "anyhow",
  "async-trait",
- "aws-hyper",
  "aws-sdk-qldbsession",
- "aws-smithy-http 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-types",
  "bb8",
  "bytes 1.1.0",
  "futures",
  "http",
  "ion-c-sys",
- "ion-rs 0.6.0",
+ "ion-rs",
  "rand 0.8.4",
  "sha2",
  "thiserror",
@@ -54,18 +54,17 @@ dependencies = [
  "atty",
  "aws-config",
  "aws-http",
- "aws-hyper",
  "aws-sdk-qldbsession",
- "aws-smithy-http 0.33.1",
- "aws-types 0.3.0",
- "bigdecimal",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-types",
  "chrono",
  "comfy-table",
  "dirs",
  "futures",
  "http",
  "ion-c-sys",
- "ion-rs 0.7.0",
+ "ion-rs",
  "itertools",
  "rustyline",
  "rustyline-derive",
@@ -149,19 +148,19 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "aws-config"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46634223c537ac88e5500cbb992afb0012b4533d8cbdfe337643bf512f3126b9"
 dependencies = [
  "aws-http",
- "aws-hyper",
  "aws-sdk-sts",
- "aws-smithy-async 0.28.0-alpha",
+ "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.28.0-alpha",
+ "aws-smithy-http",
  "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-types",
+ "aws-types",
  "bytes 1.1.0",
  "http",
  "tokio",
@@ -171,11 +170,12 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30594dc47241751ecd8bf15b3440a7ff27c0e947a0f3152863fd4c6a0e82ac90"
 dependencies = [
- "aws-smithy-http 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-http",
+ "aws-types",
  "http",
  "regex",
  "tracing",
@@ -183,87 +183,70 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6f0268ebab22b6ed41ae78b3e04c35e2bf524cce555e4ce2b78c45f2048066"
 dependencies = [
- "aws-smithy-http 0.28.0-alpha",
- "aws-smithy-types 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
  "http",
  "lazy_static",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "aws-hyper"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-client",
- "aws-smithy-http 0.28.0-alpha",
- "aws-smithy-http-tower",
- "aws-smithy-types 0.28.0-alpha",
- "bytes 1.1.0",
- "fastrand",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "pin-project",
- "tokio",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-qldbsession"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf7a7a8e42418dfe855cda9400429b86735e33ad0469a3f6a6f2b478b3aa022"
 dependencies = [
  "aws-endpoint",
  "aws-http",
- "aws-hyper",
  "aws-sig-auth",
+ "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.28.0-alpha",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-types",
+ "aws-types",
  "bytes 1.1.0",
  "http",
+ "tower",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80da5ff48de4b884a7d31138a05a5adf2db2a4b53b2457324c22019984e775d9"
 dependencies = [
  "aws-endpoint",
  "aws-http",
- "aws-hyper",
  "aws-sig-auth",
+ "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.28.0-alpha",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-query",
- "aws-smithy-types 0.28.0-alpha",
+ "aws-smithy-types",
  "aws-smithy-xml",
- "aws-types 0.0.25-alpha",
+ "aws-types",
  "bytes 1.1.0",
  "http",
+ "tower",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9dffed5192181706d6702c2ddc569341b12b1011f6ce36dbd560a846fb55ac"
 dependencies = [
  "aws-sigv4",
- "aws-smithy-http 0.28.0-alpha",
- "aws-types 0.0.25-alpha",
+ "aws-smithy-http",
+ "aws-types",
  "http",
  "thiserror",
  "tracing",
@@ -271,10 +254,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066def5814ac312f4f4c0a3aa09af45b1fca19317247b0ffa06d4b1d1f0d815a"
 dependencies = [
- "chrono",
+ "aws-smithy-http",
  "form_urlencoded",
  "hex",
  "http",
@@ -282,35 +266,30 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
+ "time 0.3.5",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907295d2d53d55ae31228647e3382be0f2f4706d6c43a7e8b23f5cfdbe224fb2"
 dependencies = [
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
-name = "aws-smithy-async"
-version = "0.33.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.3.0#fe1cfc31a925306b740e22a005fbf0ab6ec4fca7"
-dependencies = [
- "pin-project-lite",
-]
-
-[[package]]
 name = "aws-smithy-client"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484dfc5febf1290e305479288a703120fd35e996182105e4cd97afe69e0d11a0"
 dependencies = [
- "aws-smithy-async 0.28.0-alpha",
- "aws-smithy-http 0.28.0-alpha",
+ "aws-smithy-async",
+ "aws-smithy-http",
  "aws-smithy-http-tower",
- "aws-smithy-types 0.28.0-alpha",
+ "aws-smithy-types",
  "bytes 1.1.0",
  "fastrand",
  "http",
@@ -327,10 +306,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4b8e568f284def4d1edfb0705e7058928f355ae264c44359b80f021e24d419"
 dependencies = [
- "aws-smithy-types 0.28.0-alpha",
+ "aws-smithy-types",
  "bytes 1.1.0",
  "bytes-utils",
  "futures-core",
@@ -345,28 +325,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.33.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.3.0#fe1cfc31a925306b740e22a005fbf0ab6ec4fca7"
-dependencies = [
- "aws-smithy-types 0.33.1",
- "bytes 1.1.0",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "percent-encoding",
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http-tower"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db222d9dbca42fa0d19ea803826f88153c14144c38915d5121e981b45c5f2cee"
 dependencies = [
- "aws-smithy-http 0.28.0-alpha",
+ "aws-smithy-http",
  "bytes 1.1.0",
  "http",
  "http-body",
@@ -377,36 +341,28 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdb867f28532243d923fd2ef8b5a1d44e461b841e75a78c2c276b1918b5e842"
 dependencies = [
- "aws-smithy-types 0.28.0-alpha",
+ "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d2169a63763651b835912aae357cfea9ad889468aa8828117b10c2329c6231"
 dependencies = [
- "aws-smithy-types 0.28.0-alpha",
+ "aws-smithy-types",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
-dependencies = [
- "chrono",
- "itoa",
- "num-integer",
- "ryu",
-]
-
-[[package]]
-name = "aws-smithy-types"
 version = "0.33.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.3.0#fe1cfc31a925306b740e22a005fbf0ab6ec4fca7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420eb4743434a99ce9ba270bec3ef242884d407bff0bca7d16b5b0457a7d3782"
 dependencies = [
  "itoa",
  "num-integer",
@@ -416,8 +372,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.28.0-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25466637a7f68d24df5f25f69037179588419fa81991c6e198fd8f6e72ebfb07"
 dependencies = [
  "thiserror",
  "xmlparser",
@@ -425,22 +382,12 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.0.25-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.25-alpha#d6aacb5fbb501f568d53a1bcd30cb7d68619a415"
-dependencies = [
- "aws-smithy-async 0.28.0-alpha",
- "aws-smithy-types 0.28.0-alpha",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "aws-types"
 version = "0.3.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.3.0#fe1cfc31a925306b740e22a005fbf0ab6ec4fca7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d8e1b6fd4081f367682b260f55eddc4c90ac4e93ee09517f373c093366fb96"
 dependencies = [
- "aws-smithy-async 0.33.1",
- "aws-smithy-types 0.33.1",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "rustc_version",
  "tracing",
  "zeroize",
@@ -525,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
@@ -733,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,10 +710,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -1199,24 +1157,6 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b5511aa03f80ded9dd90d0244770cd7280a8eea1546fa25ea8f3e4dad0a541"
-dependencies = [
- "base64 0.12.3",
- "bigdecimal",
- "bytes 0.4.12",
- "chrono",
- "delegate",
- "ion-c-sys",
- "nom 6.1.2",
- "num-bigint",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "ion-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf75af80121752ccbbab9db0366ba35ee48ecc6167cc41fce8a634601138f8c"
@@ -1477,12 +1417,6 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
@@ -1943,15 +1877,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
 dependencies = [
- "block-buffer",
  "cfg-if",
  "cpufeatures",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2018"
 amazon-qldb-driver = { git = "https://github.com/awslabs/amazon-qldb-driver-rust", package = "amazon-qldb-driver", branch = "main" }
 
 # All of this is related to the AWS SDK for Rust
-aws_sdk_qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-sdk-qldbsession", features = ["rustls", "client"] }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-http", features = [] }
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-hyper", features = ["rustls"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.3.0", package = "aws-smithy-http", features = [] }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.3.0", package = "aws-types", features = [] }
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-config", features = [] }
+aws-sdk-qldbsession = { version = "0.3.0", features = ["rustls"] }
+aws-http = "0.3.0"
+aws-smithy-client = { version = "0.33.1", features = ["client-hyper", "rustls", "rt-tokio"] }
+aws-smithy-http = { version = "0.33.1", features = ["rt-tokio"] }
+aws-types = "0.3.0"
+aws-config = "0.3.0"
 tower = "0.4.11"
 http = "0.2.5"
 # --
@@ -23,7 +23,7 @@ http = "0.2.5"
 rustyline = "9.1.1"
 dirs = "4.0.0"
 structopt = "0.3.25"
-ion-rs = "0.7"
+ion-rs = "0.7.0"
 ion-c-sys = "0.4.12"
 chrono = "0.4.19"
 async-trait = "0.1.52"
@@ -38,14 +38,13 @@ tracing-subscriber = { version = "0.3.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2.0"
 tracing-bunyan-formatter = "0.3.1"
 comfy-table = "5.0.0"
-bigdecimal = "0.2.0"
-smallvec = "1.6.1"
+smallvec = "1.7.0"
 atty = "0.2.14"
 url = "2.2.2"
 futures = "0.3.19"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempdir = "0.3.7"
 
 [[bin]]
 name = "qldb"

--- a/src/results/table.rs
+++ b/src/results/table.rs
@@ -1,9 +1,9 @@
 use crate::ui::Ui;
 use amazon_qldb_driver::StatementResults;
 use anyhow::{anyhow, Result};
-use bigdecimal::BigDecimal;
 use comfy_table::Table;
 use ion_c_sys::timestamp::IonDateTime;
+use ion_rs::external::bigdecimal::BigDecimal;
 use ion_rs::value::*;
 use ion_rs::value::{
     owned::OwnedElement,


### PR DESCRIPTION
Other than a sdk update, the _actual_ win here is using the reexport of
BigDecimal, which means we can finally close
https://github.com/awslabs/amazon-qldb-shell/pull/135.