### PR TITLE
Prepare for a 2.0.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,21 @@ on:
   pull_request:
 
 jobs:
-
   test:
     name: Test
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macOS-latest, windows-latest ]
+        os: [ubuntu-18.04, macOS-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Env Variable Setup
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Remove MSys64 MingW64 Binaries
+        if: runner.os == 'Windows'
+        # remove this because there is a bad libclang.dll that confuses bindgen
+        run: Remove-Item -LiteralPath "C:\msys64\mingw64\bin" -Force -Recurse
+      - name: Install Dependencies
+        if: runner.os == 'Windows'
+        run: choco install llvm -y
       - name: Git Checkout
         uses: actions/checkout@v2
       - name: Rust Toolchain
@@ -43,7 +45,7 @@ jobs:
 
   release:
     name: Release
-    needs: [ test ]
+    needs: [test]
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
@@ -68,11 +70,13 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           role-duration-seconds: 1800
-
-      - name: Env Variable Setup
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Remove MSys64 MingW64 Binaries
+        if: runner.os == 'Windows'
+        # remove this because there is a bad libclang.dll that confuses bindgen
+        run: Remove-Item -LiteralPath "C:\msys64\mingw64\bin" -Force -Recurse
+      - name: Install Dependencies
+        if: runner.os == 'Windows'
+        run: choco install llvm -y
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,24 +13,31 @@ jobs:
   build:
     name: Build and Test
     runs-on: ${{ matrix.os }}
-    strategy: 
-      matrix : 
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    strategy:
+      matrix:
+        # On 2022-01-11, GitHub Actions changed the `windows-latest` virtual environment alias so
+        # that it stopped pointing to `windows-2019` and began pointing to `windows-2022` instead.
+        # The pipeline needs to be updated to support the new edition of Windows Server. In the
+        # meantime, the build only tests Windows Server 2019.
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
-      - name: Env Variable Setup 
-        if: matrix.os == 'windows-latest'
-        run: | 
-          echo "LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Remove MSys64 MingW64 Binaries
+        if: runner.os == 'Windows'
+        # remove this because there is a bad libclang.dll that confuses bindgen
+        run: Remove-Item -LiteralPath "C:\msys64\mingw64\bin" -Force -Recurse
+      - name: Install Dependencies
+        if: runner.os == 'Windows'
+        run: choco install llvm -y
       - name: Git Checkout
-        uses: actions/checkout@v2          
+        uses: actions/checkout@v2
       - name: Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Cargo Build 
+      - name: Cargo Build
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## [2.0.1] - Unreleased
+
+### Fixed
+
+- Various dependency updates, including the SDK updates (#329)
+
 ## [2.0.0] - 2021-10-14
 
 The Amazon QLDB team is pleased to announce the release of version v2.0.0 of Amazon QLDB Shell. This release is aimed at enhancing the developer experience when interacting with Amazon QLDB.
 
 ### Enhancements:
 
-* The QLDB Shell is completely rewritten in Rust to make it faster to set up and easier to use with zero external dependencies. The Shell could be run by downloading prebuilt binaries for Linux, Windows and macOS without Python installation requirement.
+- The QLDB Shell is completely rewritten in Rust to make it faster to set up and easier to use with zero external dependencies. The Shell could be run by downloading prebuilt binaries for Linux, Windows and macOS without Python installation requirement.
 
 ## [2.0.0-alpha16] - 2021-10-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "amazon_qldb_shell"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "amazon-qldb-driver",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amazon_qldb_shell"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Amazon Web Services"]
 edition = "2018"
 


### PR DESCRIPTION
We've been updating our dependencies but haven't cut a new release since
the AWS SDK moved out of alpha. This will fix at least #329.