### PR TITLE
Implement transaction countdown timer using ANSI escape codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "aws-smithy-http 0.33.1",
  "aws-smithy-http-tower",
  "aws-types 0.6.0",
+ "bus",
  "chrono",
  "comfy-table",
  "dirs",
@@ -120,6 +121,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-option"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
 
 [[package]]
 name = "atty"
@@ -548,6 +555,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "bus"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e66e1779f5b1440f1a58220ba3b3ded4427175f0a9fb8d7066521f8b4e8f2b"
+dependencies = [
+ "atomic-option",
+ "crossbeam-channel 0.4.4",
+ "num_cpus",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +612,12 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.0",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -651,6 +676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,12 +732,33 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.7",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -712,7 +767,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -796,7 +851,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -893,7 +948,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.30.0",
 ]
@@ -1041,7 +1096,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -1209,7 +1264,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1344,7 +1399,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -1361,7 +1416,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -1386,7 +1441,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1403,6 +1458,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1477,7 +1538,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset",
 ]
@@ -1599,14 +1660,28 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
 ]
@@ -1617,9 +1692,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "windows-sys 0.32.0",
 ]
@@ -1807,6 +1882,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -1821,7 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -1935,7 +2016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clipboard-win",
  "dirs-next",
  "fd-lock",
@@ -2060,7 +2141,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -2410,7 +2491,7 @@ version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2423,7 +2504,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.2",
  "time 0.3.7",
  "tracing-subscriber",
 ]
@@ -2610,7 +2691,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ smallvec = "1.8.0"
 atty = "0.2.14"
 url = "2.2.2"
 futures = "0.3.21"
+bus = "2.2.3"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use crate::runner::Runner;
 use crate::settings::{Opt, ShellConfig};
 use crate::ui::ConsoleUi;
 use crate::ui::Ui;
+use crate::timer::Timer;
 
 mod awssdk_driver;
 mod command;
@@ -20,6 +21,7 @@ mod settings;
 mod tracing;
 mod transaction;
 mod ui;
+mod timer;
 
 pub async fn run() -> Result<()> {
     let opt = Opt::from_args();
@@ -61,10 +63,12 @@ pub async fn run() -> Result<()> {
             driver,
             ui: Box::new(ui.clone()),
         };
+        let timer = Timer::new();
 
         let mut runner = Runner {
             deps,
             current_transaction: None,
+            timer
         };
 
         match runner.start().await? {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,6 +6,7 @@ use rustyline::error::ReadlineError;
 use tracing::{instrument, span, trace, Instrument, Level};
 
 use crate::transaction::ShellTransaction;
+use crate::timer::Timer;
 use crate::{
     command::{self, UseCommand},
     settings::Environment,
@@ -71,6 +72,7 @@ where
 {
     pub(crate) deps: Deps<C>,
     pub(crate) current_transaction: Option<ShellTransaction>,
+    pub timer: Timer
 }
 
 impl<C> fmt::Debug for Runner<C>

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,60 @@
+use std::{thread, time};
+use bus::Bus;
+use std::io::{self, Write};
+
+const SAVE: &str = "\x1b7";
+const RESTORE: &str = "\x1b8";
+const MOVE_TO_TOP_LEFT: &str = "\x1b[1;1H";
+const RED: &str = "\x1b[1;31m";
+const ERASE_LINE: &str = "\x1b[2K";
+const RESET: &str = "\x1b[0m";
+
+const TOTAL_TRANSACTION_TIME: u64 = 30;
+const REFRESH_INTERVAL: u64 = 100;
+
+pub struct Timer {
+    bus: Bus<String>
+}
+
+impl Timer {
+    pub fn new() -> Timer {
+        Timer {
+            bus: Bus::new(10)
+        }
+    }
+
+    pub fn start(&mut self) {
+        self.stop_timer();
+        self.run_timer();
+    }
+
+    pub fn stop(&mut self) {
+        self.stop_timer();        
+    }
+    
+    pub fn run_timer(&mut self) {
+        let mut recv = self.bus.add_rx();
+        thread::spawn(move || {
+            let start = time::Instant::now();
+            loop {
+                if recv.try_recv().is_ok() {
+                    break
+                }
+                let duration = TOTAL_TRANSACTION_TIME - start.elapsed().as_secs();
+                if duration > 0 {
+                    print!("{} {:?} {}", SAVE.to_owned() + MOVE_TO_TOP_LEFT + ERASE_LINE + RED, duration, RESTORE.to_owned() + RESET);
+                    io::stdout().flush().unwrap();
+                } else {
+                    print!("{} {} {}", SAVE.to_owned() + MOVE_TO_TOP_LEFT + ERASE_LINE + RED, "TIMEOUT", RESTORE.to_owned() + RESET);
+                    io::stdout().flush().unwrap();
+                    break
+                }
+                thread::sleep(time::Duration::from_millis(REFRESH_INTERVAL));
+            }
+        });
+    }
+
+    pub fn stop_timer(&mut self) {
+        self.bus.broadcast("stop".to_string());
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -124,6 +124,7 @@ where
 
         let new_tx = new_transaction(self.deps.driver.clone());
         self.current_transaction.replace(new_tx);
+        self.timer.start();
         Ok(())
     }
 
@@ -208,6 +209,7 @@ where
     }
 
     pub(crate) async fn handle_commit(&mut self) -> Result<()> {
+        self.timer.stop();
         let mut tx = self
             .current_transaction
             .take()


### PR DESCRIPTION
*Issue #, if available:*
#203 

*Description of changes:*
This is a bit of a hacky change until I figure out how to make asynchronous calls to draw prompts using the `rustylines`, or use another readline implementation altogether.

This solution relies on the customer's terminal handling the `ESC7` and `ESC8` [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) as Save Cursor Position and Restore Cursor Position, respectively. This is supported in [VT100 Mode](https://www.xfree86.org/current/ctlseqs.html), which is apparently supported by the `xterm` terminal emulator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
