### PR TITLE
remove gh token from dependabot auto merge action

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -24,8 +24,7 @@ jobs:
               event: 'APPROVE'
             })
             github.rest.pulls.merge({
-              owner: context.payload.repository.owner.login,
+              owner: context.payload.repository.owner,
               repo: context.payload.repository.name,
               pull_number: ${{env.pull_request_number}},
             })
-          github-token: ${{secrets.WRITE_TOKEN}}


### PR DESCRIPTION
https://github.com/marketplace/actions/github-script?version=v5.0.0#examples

It appears that the github-token setting is for overriding the default job token

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
